### PR TITLE
Add Panteleyev jpackage plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ java -jar target/dofus-drop-calculator.jar
 Pour créer un exécutable Windows embarquant la JRE et JavaFX :
 
 ```bash
-mvn clean javafx:jpackage
+mvn clean javafx:jlink jpackage:jpackage
 ```
 
-Le résultat se trouve dans `target/jpackage/` et fonctionne sans Java installé.
+Le résultat se trouve dans `target/installer/` et fonctionne sans Java installé.
 
 ## Lancer le JAR avec les bibliothèques natives
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,34 @@
                 <configuration>
                     <mainClass>boune.DofusDropCalculator</mainClass>
                     <appName>DofusDropCalculator</appName>
+                    <jlinkImageName>image</jlinkImageName>
                 </configuration>
                 <executions>
                     <execution>
+                        <id>create-runtime</id>
                         <goals>
-                            <goal>jpackage</goal>
+                            <goal>jlink</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.panteleyev</groupId>
+                <artifactId>jpackage-maven-plugin</artifactId>
+                <version>1.6.6</version>
+                <executions>
+                    <execution>
+                        <id>package-windows</id>
+                        <goals><goal>jpackage</goal></goals>
+                        <configuration>
+                            <name>DofusDropCalculator</name>
+                            <destination>${project.build.directory}/installer</destination>
+                            <runtimeImage>${project.build.directory}/image</runtimeImage>
+                            <winMenu>true</winMenu>
+                            <icon>${project.basedir}/src/main/resources/icon.ico</icon>
+                            <winShortcut>true</winShortcut>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary
- configure javafx-maven-plugin for jlink runtime image
- add org.panteleyev jpackage-maven-plugin
- provide placeholder Windows icon
- document the new build steps for jpackage

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.openjfx:javafx-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686eb7e12e70832e978973c00e1d20e4