### PR TITLE
Fix JavaFX fat-jar startup with launcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.8</version>
                 <configuration>
-                    <mainClass>boune.DofusDropCalculator</mainClass>
+                    <mainClass>boune.Launcher</mainClass>
                 </configuration>
             </plugin>
             <plugin>
@@ -79,7 +79,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>boune.DofusDropCalculator</mainClass>
+                                    <mainClass>boune.Launcher</mainClass>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>

--- a/src/main/java/boune/Launcher.java
+++ b/src/main/java/boune/Launcher.java
@@ -1,0 +1,7 @@
+package boune;
+
+public class Launcher {
+    public static void main(String[] args) {
+        DofusDropCalculator.main(args);
+    }
+}


### PR DESCRIPTION
## Summary
- add a launcher class that delegates to `DofusDropCalculator`
- configure Maven plugins to use the launcher for execution

## Testing
- `mvn -q -DskipTests package` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec2098d5c832e9de0d21188cbb110