### PR TITLE
Add Maven clean plugin configuration and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,16 @@ Assurez-vous de lancer la commande Maven depuis la racine du projet :
 cd ..
 mvn clean package
 ```
+
+## Résolution du dossier `target` verrouillé
+
+Sous Windows, `mvn clean` peut échouer si un processus garde un fichier ouvert
+dans `target/`. Fermez toute fenêtre exécutant le JAR ou un test JavaFX,
+puis relancez :
+
+```powershell
+mvn -U clean package
+```
+
+Le `pom.xml` configure désormais le plugin `maven-clean-plugin` avec
+`failOnError=false` pour continuer le build même en cas de fichier verrouillé.

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
                 <configuration><release>${java.version}</release></configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.8</version>


### PR DESCRIPTION
## Summary
- configure `maven-clean-plugin` to continue even if files are locked
- document how to rebuild when `target/` is locked on Windows

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4439a1c832eac28cd93d363fa4c