### PR TITLE
Fix FXML padding coercion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
                 <version>0.0.8</version>
                 <configuration>
                     <mainClass>boune.Launcher</mainClass>
-                    <jvmArgs>--enable-native-access=ALL-UNNAMED</jvmArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/resources/boune/ui/MainView.fxml
+++ b/src/main/resources/boune/ui/MainView.fxml
@@ -16,7 +16,7 @@
     </top>
 
     <center>
-        <GridPane hgap="10" vgap="10" padding="20">
+        <GridPane hgap="10" vgap="10" padding="Insets(20)">
             <Label text="Taux de drop de base (%) :" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
             <TextField fx:id="tauxField" promptText="1.0" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
 
@@ -30,7 +30,7 @@
     </center>
 
     <bottom>
-        <VBox spacing="5" padding="15">
+        <VBox spacing="5" padding="Insets(15)">
             <Label text="Résultats :" styleClass="subtitle"/>
             <TextArea fx:id="resultArea" editable="false" prefRowCount="5"/>
         </VBox>


### PR DESCRIPTION
## Summary
- fix FXML padding syntax so JavaFX parser gets Insets
- remove jvmArgs option from javafx-maven-plugin

## Testing
- `mvn javafx:run` *(fails: No plugin found for prefix 'javafx')*

------
https://chatgpt.com/codex/tasks/task_e_686ed68726ac832eab0106e02b16b324